### PR TITLE
Make name configurable for each health check

### DIFF
--- a/samples/MvcSample/Properties/AssemblyInfo.cs
+++ b/samples/MvcSample/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]

--- a/samples/MvcSample/Startup.cs
+++ b/samples/MvcSample/Startup.cs
@@ -21,12 +21,11 @@ namespace MvcSample
                 //    "select 'a'"),
                 new PingHealthCheck(new PingHealthCheckOptions().AddHost("localhost", 1000)));
 
-            /* Sample with named checks
+            // Sample with named checks
             app.UseHealthChecks(
-                "/_health",
+                "/_health_named",
                 new HealthCheckWrapper(new NoopHealthCheck(), "Noop health check"),
                 new HealthCheckWrapper(new PingHealthCheck(new PingHealthCheckOptions().AddHost("localhost", 1000)), "Ping to localhost"));
-            */
         }
     }
 

--- a/samples/MvcSample/Startup.cs
+++ b/samples/MvcSample/Startup.cs
@@ -20,6 +20,13 @@ namespace MvcSample
                 //    @"Data Source=(LocalDB)\v13.0;Integrated Security=True;Initial Catalog=master",
                 //    "select 'a'"),
                 new PingHealthCheck(new PingHealthCheckOptions().AddHost("localhost", 1000)));
+
+            /* Sample with named checks
+            app.UseHealthChecks(
+                "/_health",
+                new HealthCheckWrapper(new NoopHealthCheck(), "Noop health check"),
+                new HealthCheckWrapper(new PingHealthCheck(new PingHealthCheckOptions().AddHost("localhost", 1000)), "Ping to localhost"));
+            */
         }
     }
 

--- a/src/RimDev.AspNet.Diagnostics.HealthChecks/HealthCheckMiddleware.cs
+++ b/src/RimDev.AspNet.Diagnostics.HealthChecks/HealthCheckMiddleware.cs
@@ -19,13 +19,21 @@ namespace RimDev.AspNet.Diagnostics.HealthChecks
         private readonly OwinMiddleware _next;
         private readonly HealthCheckOptions _healthCheckOptions;
         private readonly RimDevAspNetHealthCheckService _healthCheckService;
-        private readonly IHealthCheck[] _healthChecks;
+        private readonly HealthCheckWrapper[] _healthChecks;
 
         public HealthCheckMiddleware(
             OwinMiddleware next,
             ILogger logger,
             HealthCheckOptions healthCheckOptions,
             IHealthCheck[] healthChecks)
+            : this(next, logger, healthCheckOptions, healthChecks.Select(healthCheck => new HealthCheckWrapper(healthCheck)).ToArray())
+        { }
+
+        public HealthCheckMiddleware(
+            OwinMiddleware next,
+            ILogger logger,
+            HealthCheckOptions healthCheckOptions,
+            HealthCheckWrapper[] healthChecks)
             : base(next)
         {
             if (next == null)

--- a/src/RimDev.AspNet.Diagnostics.HealthChecks/HealthCheckWrapper.cs
+++ b/src/RimDev.AspNet.Diagnostics.HealthChecks/HealthCheckWrapper.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace RimDev.AspNet.Diagnostics.HealthChecks
+{
+    public class HealthCheckWrapper
+    {
+        public HealthCheckWrapper(IHealthCheck healthCheck, string name = null)
+        {
+            HealthCheck = healthCheck;
+            
+            if (string.IsNullOrWhiteSpace(name))
+                name = healthCheck.GetType().Name;
+
+            Name = name;
+        }
+        public IHealthCheck HealthCheck { get; }
+        public string Name { get; }
+    }
+}

--- a/src/RimDev.AspNet.Diagnostics.HealthChecks/IAppBuilderExtensions.cs
+++ b/src/RimDev.AspNet.Diagnostics.HealthChecks/IAppBuilderExtensions.cs
@@ -84,7 +84,8 @@ namespace RimDev.AspNet.Diagnostics.HealthChecks
         {
             UseHealthChecks(app, url, new HealthCheckOptions(), healthChecks.ToArray());
         }
-      public static void UseHealthChecks(
+
+        public static void UseHealthChecks(
             this IAppBuilder app,
             string url,
             params HealthCheckWrapper[] healthChecks)

--- a/src/RimDev.AspNet.Diagnostics.HealthChecks/IAppBuilderExtensions.cs
+++ b/src/RimDev.AspNet.Diagnostics.HealthChecks/IAppBuilderExtensions.cs
@@ -1,7 +1,8 @@
-﻿using Microsoft.Extensions.Diagnostics.HealthChecks;
-using Owin;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+using Owin;
 
 namespace RimDev.AspNet.Diagnostics.HealthChecks
 {
@@ -10,11 +11,15 @@ namespace RimDev.AspNet.Diagnostics.HealthChecks
         public static void UseHealthChecks(
             this IAppBuilder app,
             string url,
+            ILogger logger,
             HealthCheckOptions options,
-            params IHealthCheck[] healthChecks)
+            params HealthCheckWrapper[] healthChecks)
         {
-            var loggerFactory = new Microsoft.Extensions.Logging.LoggerFactory();
-            var logger = loggerFactory.CreateLogger(nameof(HealthCheckMiddleware));
+            if (logger == null)
+            {
+                var loggerFactory = new LoggerFactory();
+                logger = loggerFactory.CreateLogger(nameof(HealthCheckMiddleware));
+            }
 
             app.Map(url, appBuilder =>
             {
@@ -23,6 +28,36 @@ namespace RimDev.AspNet.Diagnostics.HealthChecks
                     options,
                     healthChecks);
             });
+        }
+        public static void UseHealthChecks(
+            this IAppBuilder app,
+            string url,
+            ILogger logger,
+            HealthCheckOptions options,
+            params IHealthCheck[] healthChecks)
+        {
+            if (logger == null)
+            {
+                var loggerFactory = new LoggerFactory();
+                logger = loggerFactory.CreateLogger(nameof(HealthCheckMiddleware));
+            }
+
+            app.Map(url, appBuilder =>
+            {
+                appBuilder.Use<HealthCheckMiddleware>(
+                    logger,
+                    options,
+                    healthChecks);
+            });
+        }
+
+        public static void UseHealthChecks(
+            this IAppBuilder app,
+            string url,
+            HealthCheckOptions options,
+            params IHealthCheck[] healthChecks)
+        {
+            UseHealthChecks(app, url, null, options, healthChecks);
         }
 
         public static void UseHealthChecks(
@@ -48,6 +83,22 @@ namespace RimDev.AspNet.Diagnostics.HealthChecks
             IEnumerable<IHealthCheck> healthChecks)
         {
             UseHealthChecks(app, url, new HealthCheckOptions(), healthChecks.ToArray());
+        }
+      public static void UseHealthChecks(
+            this IAppBuilder app,
+            string url,
+            params HealthCheckWrapper[] healthChecks)
+        {
+            UseHealthChecks(app, url, new HealthCheckOptions(), healthChecks);
+        }
+
+        public static void UseHealthChecks(
+            this IAppBuilder app,
+            string url,
+            HealthCheckOptions options,
+            IEnumerable<HealthCheckWrapper> healthChecks)
+        {
+            UseHealthChecks(app, url, null, options, healthChecks.ToArray());
         }
     }
 }

--- a/src/RimDev.AspNet.Diagnostics.HealthChecks/Properties/AssemblyInfo.cs
+++ b/src/RimDev.AspNet.Diagnostics.HealthChecks/Properties/AssemblyInfo.cs
@@ -10,5 +10,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("5ba7da7c-bf46-4064-ab4f-50f4165e70f3")]
 
-[assembly: AssemblyVersion("1.0.1.0")]
-[assembly: AssemblyFileVersion("1.0.1.0")]
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]

--- a/src/RimDev.AspNet.Diagnostics.HealthChecks/RimDev.AspNet.Diagnostics.HealthChecks.csproj
+++ b/src/RimDev.AspNet.Diagnostics.HealthChecks/RimDev.AspNet.Diagnostics.HealthChecks.csproj
@@ -104,6 +104,7 @@
     <Compile Include="HealthCheckMiddleware.cs" />
     <Compile Include="HealthCheckOptions.cs" />
     <Compile Include="HealthCheckResponseWriters.cs" />
+    <Compile Include="HealthCheckWrapper.cs" />
     <Compile Include="IAppBuilderExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RimDevAspNetHealthCheckService.cs" />

--- a/src/RimDev.AspNet.Diagnostics.HealthChecks/RimDevAspNetHealthCheckService.cs
+++ b/src/RimDev.AspNet.Diagnostics.HealthChecks/RimDevAspNetHealthCheckService.cs
@@ -52,7 +52,7 @@ namespace RimDev.AspNet.Diagnostics.HealthChecks
                 {
                     var stopwatch = Stopwatch.StartNew();
 
-                    Log.HealthCheckBegin(_logger, wrapper.HealthCheck);
+                    Log.HealthCheckBegin(_logger, wrapper);
 
                     HealthReportEntry entry;
                     try
@@ -76,8 +76,8 @@ namespace RimDev.AspNet.Diagnostics.HealthChecks
                             exception: result.Exception,
                             data: result.Data);
 
-                        Log.HealthCheckEnd(_logger, wrapper.HealthCheck, entry, duration);
-                        Log.HealthCheckData(_logger, wrapper.HealthCheck, entry);
+                        Log.HealthCheckEnd(_logger, wrapper, entry, duration);
+                        Log.HealthCheckData(_logger, wrapper, entry);
                     }
 
                     // Allow cancellation to propagate.
@@ -91,7 +91,7 @@ namespace RimDev.AspNet.Diagnostics.HealthChecks
                             exception: ex,
                             data: null);
 
-                        Log.HealthCheckError(_logger, wrapper.HealthCheck, ex, duration);
+                        Log.HealthCheckError(_logger, wrapper, ex, duration);
                     }
 
                     entries[wrapper.Name] = entry;
@@ -173,42 +173,42 @@ namespace RimDev.AspNet.Diagnostics.HealthChecks
                 _healthCheckProcessingEnd(logger, duration.TotalMilliseconds, status, null);
             }
 
-            public static void HealthCheckBegin(ILogger logger, IHealthCheck healthCheck)
+            public static void HealthCheckBegin(ILogger logger, HealthCheckWrapper healthCheck)
             {
-                _healthCheckBegin(logger, healthCheck.GetType().Name, null);
+                _healthCheckBegin(logger, healthCheck.Name, null);
             }
 
-            public static void HealthCheckEnd(ILogger logger, IHealthCheck healthCheck, HealthReportEntry entry, TimeSpan duration)
+            public static void HealthCheckEnd(ILogger logger, HealthCheckWrapper healthCheck, HealthReportEntry entry, TimeSpan duration)
             {
                 switch (entry.Status)
                 {
                     case HealthStatus.Healthy:
-                        _healthCheckEndHealthy(logger, healthCheck.GetType().Name, duration.TotalMilliseconds, entry.Status, entry.Description, null);
+                        _healthCheckEndHealthy(logger, healthCheck.Name, duration.TotalMilliseconds, entry.Status, entry.Description, null);
                         break;
 
                     case HealthStatus.Degraded:
-                        _healthCheckEndDegraded(logger, healthCheck.GetType().Name, duration.TotalMilliseconds, entry.Status, entry.Description, null);
+                        _healthCheckEndDegraded(logger, healthCheck.Name, duration.TotalMilliseconds, entry.Status, entry.Description, null);
                         break;
 
                     case HealthStatus.Unhealthy:
-                        _healthCheckEndUnhealthy(logger, healthCheck.GetType().Name, duration.TotalMilliseconds, entry.Status, entry.Description, null);
+                        _healthCheckEndUnhealthy(logger, healthCheck.Name, duration.TotalMilliseconds, entry.Status, entry.Description, null);
                         break;
                 }
             }
 
-            public static void HealthCheckError(ILogger logger, IHealthCheck healthCheck, Exception exception, TimeSpan duration)
+            public static void HealthCheckError(ILogger logger, HealthCheckWrapper healthCheck, Exception exception, TimeSpan duration)
             {
-                _healthCheckError(logger, healthCheck.GetType().Name, duration.TotalMilliseconds, exception);
+                _healthCheckError(logger, healthCheck.Name, duration.TotalMilliseconds, exception);
             }
 
-            public static void HealthCheckData(ILogger logger, IHealthCheck healthCheck, HealthReportEntry entry)
+            public static void HealthCheckData(ILogger logger, HealthCheckWrapper healthCheck, HealthReportEntry entry)
             {
                 if (entry.Data.Count > 0 && logger.IsEnabled(LogLevel.Debug))
                 {
                     logger.Log(
                         LogLevel.Debug,
                         EventIds.HealthCheckData,
-                        new HealthCheckDataLogValue(healthCheck.GetType().Name, entry.Data),
+                        new HealthCheckDataLogValue(healthCheck.Name, entry.Data),
                         null,
                         (state, ex) => state.ToString());
                 }


### PR DESCRIPTION
Added a wrapper class around IHealthCheck so a name can be supplied. This is really useful when using the endpoint with https://www.nuget.org/packages/AspNetCore.HealthChecks.UI/.

This change makes the service work with this wrapper class internally though it will fall back to the health check class name if no name is specified. I've kept all the extensions using IHealthCheck as well to be backwards compatible.