### PR TITLE
Add a response writer that outputs the expected format for the UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,32 @@ public class Startup
 }
 ```
 
+### Usage with Health Checks UI
+
+To use with the [Health Checks UI project](https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks#healthcheckui-and-failure-notifications)
+named health checks should be used. and a special ResponseWriter needs to be confiugred. This returns the checks with more specific information
+about each check in a format that the UI project can read.
+
+```csharp
+public class Startup
+{
+    public void Configuration(IAppBuilder app)
+    {
+        app.UseHealthChecks(
+            "/_health_ui",
+            new HealthCheckOptions
+            {
+                ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse
+            },
+            new HealthCheckWrapper(new NoopHealthCheck(), "Noop health check"),
+            new HealthCheckWrapper(new PingHealthCheck(new PingHealthCheckOptions().AddHost("localhost", 1000)), "Ping to localhost"));
+    }
+}
+```
+
+The UI can't be hosted in a full framework app but can easily be setup using the official [docker image](https://hub.docker.com/r/xabarilcoding/healthchecksui/)
+for those who doesn't already have a UI project set up.
+
 ## Requirements
 
 - .NET Framework 4.6.2 or later

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ public class Startup
 ### Usage with Health Checks UI
 
 To use with the [Health Checks UI project](https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks#healthcheckui-and-failure-notifications)
-named health checks should be used. and a special ResponseWriter needs to be confiugred. This returns the checks with more specific information
+named health checks should be used and a special ResponseWriter needs to be configured. This returns the checks with more specific information
 about each check in a format that the UI project can read.
 
 ```csharp

--- a/samples/MvcSample/Properties/AssemblyInfo.cs
+++ b/samples/MvcSample/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
+[assembly: AssemblyVersion("1.2.0.0")]
+[assembly: AssemblyFileVersion("1.2.0.0")]

--- a/samples/MvcSample/Startup.cs
+++ b/samples/MvcSample/Startup.cs
@@ -1,10 +1,10 @@
 ﻿using HealthChecks.Network;
-using HealthChecks.SqlServer;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Owin;
 using RimDev.AspNet.Diagnostics.HealthChecks;
 using System.Threading;
 using System.Threading.Tasks;
+using RimDev.AspNet.Diagnostics.HealthChecks.UI;
 
 namespace MvcSample
 {
@@ -21,10 +21,15 @@ namespace MvcSample
                 //    "select 'a'"),
                 new PingHealthCheck(new PingHealthCheckOptions().AddHost("localhost", 1000)));
 
-            // Sample with named checks
+            // Sample with named checks for Health Check UI project
             app.UseHealthChecks(
-                "/_health_named",
+                "/_health_ui",
+                new HealthCheckOptions
+                {
+                    ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse
+                },
                 new HealthCheckWrapper(new NoopHealthCheck(), "Noop health check"),
+                new HealthCheckWrapper(new FailingHealthCheck(), "Failing health check"),
                 new HealthCheckWrapper(new PingHealthCheck(new PingHealthCheckOptions().AddHost("localhost", 1000)), "Ping to localhost"));
         }
     }
@@ -48,6 +53,16 @@ namespace MvcSample
             await Task.Delay(1000);
 
             return new HealthCheckResult(HealthStatus.Healthy);
+        }
+    }
+
+    public class FailingHealthCheck : IHealthCheck
+    {
+        public Task<HealthCheckResult> CheckHealthAsync(
+            HealthCheckContext context,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return Task.FromResult(new HealthCheckResult(HealthStatus.Unhealthy, "This one is supposed to fail."));
         }
     }
 }

--- a/src/RimDev.AspNet.Diagnostics.HealthChecks/IAppBuilderExtensions.cs
+++ b/src/RimDev.AspNet.Diagnostics.HealthChecks/IAppBuilderExtensions.cs
@@ -97,6 +97,15 @@ namespace RimDev.AspNet.Diagnostics.HealthChecks
             this IAppBuilder app,
             string url,
             HealthCheckOptions options,
+            params HealthCheckWrapper[] healthChecks)
+        {
+            UseHealthChecks(app, url, null, options, healthChecks);
+        }
+
+        public static void UseHealthChecks(
+            this IAppBuilder app,
+            string url,
+            HealthCheckOptions options,
             IEnumerable<HealthCheckWrapper> healthChecks)
         {
             UseHealthChecks(app, url, null, options, healthChecks.ToArray());

--- a/src/RimDev.AspNet.Diagnostics.HealthChecks/Properties/AssemblyInfo.cs
+++ b/src/RimDev.AspNet.Diagnostics.HealthChecks/Properties/AssemblyInfo.cs
@@ -10,5 +10,5 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("5ba7da7c-bf46-4064-ab4f-50f4165e70f3")]
 
-[assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
+[assembly: AssemblyVersion("1.2.0.0")]
+[assembly: AssemblyFileVersion("1.2.0.0")]

--- a/src/RimDev.AspNet.Diagnostics.HealthChecks/RimDev.AspNet.Diagnostics.HealthChecks.csproj
+++ b/src/RimDev.AspNet.Diagnostics.HealthChecks/RimDev.AspNet.Diagnostics.HealthChecks.csproj
@@ -70,6 +70,9 @@
     <Reference Include="Microsoft.Owin, Version=3.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Owin.3.1.0\lib\net45\Microsoft.Owin.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
     </Reference>
@@ -108,10 +111,13 @@
     <Compile Include="IAppBuilderExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RimDevAspNetHealthCheckService.cs" />
+    <Compile Include="UI\UIHealthReport.cs" />
+    <Compile Include="UI\UIResponseWriter.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="RimDev.AspNet.Diagnostics.HealthChecks.nuspec" />
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/RimDev.AspNet.Diagnostics.HealthChecks/RimDev.AspNet.Diagnostics.HealthChecks.nuspec
+++ b/src/RimDev.AspNet.Diagnostics.HealthChecks/RimDev.AspNet.Diagnostics.HealthChecks.nuspec
@@ -14,6 +14,7 @@
       <dependency id="Microsoft.Extensions.Diagnostics.HealthChecks" version="2.2.0" />
       <dependency id="Microsoft.Extensions.Logging" version="2.2.0" />
       <dependency id="Microsoft.Owin" version="3.1.0" />
+      <dependency id="Newtonsoft.Json" version="9.0.1" />
     </dependencies>
   </metadata>
 </package>

--- a/src/RimDev.AspNet.Diagnostics.HealthChecks/UI/UIHealthReport.cs
+++ b/src/RimDev.AspNet.Diagnostics.HealthChecks/UI/UIHealthReport.cs
@@ -1,0 +1,74 @@
+﻿// Adapted from https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/tree/2.2.0-upgrade-ui-client-2.2.3/src/HealthChecks.UI.Client
+// Originally licensed under the Apache License, Version 2.0, https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/blob/2.2.0-upgrade-ui-client-2.2.3/LICENSE
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace RimDev.AspNet.Diagnostics.HealthChecks.UI
+{
+    /*
+     * Models for UI Client. This models represent a indirection between HealthChecks API and 
+     * UI Client in order to implement some features not present on HealthChecks of substitute 
+     * some properties etc.
+     */
+    public class UIHealthReport
+    {
+        public UIHealthStatus Status { get; set; }
+        public TimeSpan TotalDuration { get; set; }
+        public Dictionary<string, UIHealthReportEntry> Entries { get; }
+
+        public UIHealthReport(Dictionary<string, UIHealthReportEntry> entries, TimeSpan totalDuration)
+        {
+            Entries = entries;
+            TotalDuration = totalDuration;
+        }
+
+        public static UIHealthReport CreateFrom(HealthReport report)
+        {
+            var uiReport = new UIHealthReport(new Dictionary<string, UIHealthReportEntry>(), report.TotalDuration)
+            {
+                Status = (UIHealthStatus) report.Status,
+            };
+
+            foreach (var item in report.Entries)
+            {
+                var entry = new UIHealthReportEntry
+                {
+                    Data = item.Value.Data,
+                    Description = item.Value.Description,
+                    Duration = item.Value.Duration,
+                    Status = (UIHealthStatus) item.Value.Status
+                };
+
+                if (item.Value.Exception != null)
+                {
+                    var message = item.Value.Exception?.Message;
+
+                    entry.Exception = message;
+                    entry.Description = item.Value.Description ?? message;
+                }
+
+                uiReport.Entries.Add(item.Key, entry);
+            }
+
+            return uiReport;
+        }
+    }
+
+    public enum UIHealthStatus
+    {
+        Unhealthy = 0,
+        Degraded = 1,
+        Healthy = 2
+    }
+
+    public class UIHealthReportEntry
+    {
+        public IReadOnlyDictionary<string, object> Data { get; set; }
+        public string Description { get; set; }
+        public TimeSpan Duration { get; set; }
+        public string Exception { get; set; }
+        public UIHealthStatus Status { get; set; }
+    }
+}

--- a/src/RimDev.AspNet.Diagnostics.HealthChecks/UI/UIResponseWriter.cs
+++ b/src/RimDev.AspNet.Diagnostics.HealthChecks/UI/UIResponseWriter.cs
@@ -1,0 +1,54 @@
+﻿// Adapted from https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/tree/2.2.0-upgrade-ui-client-2.2.3/src/HealthChecks.UI.Client
+// Originally licensed under the Apache License, Version 2.0, https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/blob/2.2.0-upgrade-ui-client-2.2.3/LICENSE
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Owin;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Serialization;
+
+namespace RimDev.AspNet.Diagnostics.HealthChecks.UI
+{
+    public static class UIResponseWriter
+    {
+        const string DEFAULT_CONTENT_TYPE = "application/json";
+
+        public static Task WriteHealthCheckUIResponse(IOwinContext httpContext, HealthReport report) => WriteHealthCheckUIResponse(httpContext, report, null);
+
+        public static Task WriteHealthCheckUIResponse(IOwinContext httpContext, HealthReport report, Action<JsonSerializerSettings> jsonConfigurator)
+        {
+            var response = "{}";
+
+            if (report != null)
+            {
+                var settings = new JsonSerializerSettings()
+                {
+                    ContractResolver = new DefaultContractResolver
+                    {
+                        NamingStrategy = new CamelCaseNamingStrategy
+                        {
+                            ProcessDictionaryKeys = false
+                        }
+                    },
+                    NullValueHandling = NullValueHandling.Ignore,
+                    ReferenceLoopHandling = ReferenceLoopHandling.Ignore
+                };
+
+                jsonConfigurator?.Invoke(settings);
+
+                settings.Converters.Add(new StringEnumConverter());
+
+                httpContext.Response.ContentType = DEFAULT_CONTENT_TYPE;
+
+                var uiReport = UIHealthReport
+                    .CreateFrom(report);
+
+                response = JsonConvert.SerializeObject(uiReport, settings);
+            }
+
+            return httpContext.Response.WriteAsync(response);
+        }
+    }
+}

--- a/src/RimDev.AspNet.Diagnostics.HealthChecks/packages.config
+++ b/src/RimDev.AspNet.Diagnostics.HealthChecks/packages.config
@@ -13,6 +13,7 @@
   <package id="Microsoft.Extensions.Options" version="2.2.0" targetFramework="net462" />
   <package id="Microsoft.Extensions.Primitives" version="2.2.0" targetFramework="net462" />
   <package id="Microsoft.Owin" version="3.1.0" targetFramework="net462" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net462" />
   <package id="Owin" version="1.0" targetFramework="net462" />
   <package id="System.Buffers" version="4.4.0" targetFramework="net462" />
   <package id="System.ComponentModel.Annotations" version="4.5.0" targetFramework="net462" />


### PR DESCRIPTION
Added the required response writer for the UI, updated samples, readme and nuspec.

Note that this takes a dependency on Newtonsoft Json version 9.0.1 for serializing the response. It might be possible to go even further back if needed but this felt like a good trade off between using the latest and greatest and being backwards compatible.